### PR TITLE
PAYARA-3859: Fix MP Rest client return type handling

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -250,7 +250,7 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey.ext</groupId>
+                <groupId>org.glassfish.jersey.ext.microprofile</groupId>
                 <artifactId>jersey-mp-rest-client</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -20,8 +20,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>jersey-microprofile</artifactId>
-        <groupId>org.glassfish.jersey.ext</groupId>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.ext.microprofile</groupId>
         <version>2.29.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -146,16 +146,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!--<parallel>classes</parallel>
-                    <perCoreThreadCount>true</perCoreThreadCount>
-                    <threadCount>1</threadCount>
-                    <forkCount>1C</forkCount>
-                    <reuseForks>true</reuseForks>-->
-                    <suiteXmlFiles>
-                        <suiteXmlFile>tck-suite.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                </configuration>
+                <executions>
+                    <!-- run junit tests in default-test, tck in extra execution -->
+                    <execution>
+                        <id>tck</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <!--<parallel>classes</parallel>
+                            <perCoreThreadCount>true</perCoreThreadCount>
+                            <threadCount>1</threadCount>
+                            <forkCount>1C</forkCount>
+                            <reuseForks>true</reuseForks>-->
+                            <suiteXmlFiles>
+                                <suiteXmlFile>tck-suite.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>uk.co.deliverymind</groupId>

--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/ConfigWrapper.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/ConfigWrapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package org.glassfish.jersey.microprofile.restclient;
 
 import java.util.Collection;

--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/ExecutorServiceWrapper.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/ExecutorServiceWrapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package org.glassfish.jersey.microprofile.restclient;
 
 import java.util.Collection;

--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientModel.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientModel.java
@@ -102,6 +102,10 @@ class RestClientModel {
         }
     }
 
+    Class<?> getRestClientClass() {
+        return interfaceModel.getRestClientClass();
+    }
+
     private static Map<Method, MethodModel> parseMethodModels(InterfaceModel classModel) {
         Map<Method, MethodModel> methodMap = new HashMap<>();
         for (Method method : classModel.getRestClientClass().getMethods()) {

--- a/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/ApplicationResource.java
+++ b/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/ApplicationResource.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +17,19 @@
 
 package org.glassfish.jersey.microprofile.restclient;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
 
 /**
- * Created by David Kral.
+ * @author David Kral
+ * @author Patrik Dudits
  */
 
 @Path("resource")
@@ -32,6 +40,20 @@ public interface ApplicationResource {
 
     @POST
     String postAppendValue(String value);
+
+    @Path("list/{size}")
+    @GET
+    List<String> list(@PathParam("size") int size);
+
+    @Path("intmap/{size}")
+    @GET
+    Map<String, Integer> map(@PathParam("size") int size);
+
+    @Path("list")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Integer> acceptList(List<Integer> numbers);
 
     default String sayHi() {
         return "Hi";

--- a/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/ApplicationResourceImpl.java
+++ b/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/ApplicationResourceImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +17,16 @@
 
 package org.glassfish.jersey.microprofile.restclient;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
- * Created by David Kral.
+ * @author David Kral
+ * @author Patrik Dudits
  */
 public class ApplicationResourceImpl implements ApplicationResource {
     @Override
@@ -28,5 +37,22 @@ public class ApplicationResourceImpl implements ApplicationResource {
     @Override
     public String postAppendValue(String value) {
         return null;
+    }
+
+    @Override
+    public List<String> list(int size) {
+        return IntStream.rangeClosed(1, size).mapToObj(i -> "int" + i).collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, Integer> map(int size) {
+        return IntStream.rangeClosed(1, size).mapToObj(i -> i).collect(Collectors.toMap(String::valueOf, Function.identity()));
+    }
+
+    @Override
+    public Map<String, Integer> acceptList(List<Integer> numbers) {
+        Map<String, Integer> result = new HashMap<>();
+        result.put("size", numbers != null ? numbers.size() : -1);
+        return result;
     }
 }

--- a/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/RestClientModelTest.java
+++ b/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/RestClientModelTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +19,8 @@ package org.glassfish.jersey.microprofile.restclient;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Map;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -28,7 +31,8 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Created by David Kral.
+ * @author David Kral
+ * @author Patrik Dudits
  */
 public class RestClientModelTest extends JerseyTest {
     @Override
@@ -44,5 +48,34 @@ public class RestClientModelTest extends JerseyTest {
                 .build(ApplicationResource.class);
         assertEquals("This is default value!", app.getValue());
         assertEquals("Hi", app.sayHi());
+    }
+
+    @Test
+    public void testList() {
+        ApplicationResource app = RestClientBuilder.newBuilder()
+                .baseUri(URI.create("http://localhost:9998"))
+                .build(ApplicationResource.class);
+        assertEquals(Arrays.asList("int1", "int2", "int3"), app.list(3));
+    }
+
+    @Test
+    public void testMap() {
+        ApplicationResource app = RestClientBuilder.newBuilder()
+                .baseUri(URI.create("http://localhost:9998"))
+                .build(ApplicationResource.class);
+        Map<String, Integer> map = app.map(20);
+        assertEquals(20, map.size());
+        for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            assertEquals(entry.getKey(), entry.getValue().toString());
+        }
+    }
+
+    @Test
+    public void testListParameter() {
+        ApplicationResource app = RestClientBuilder.newBuilder()
+                .baseUri(URI.create("http://localhost:9998"))
+                .build(ApplicationResource.class);
+        Map<String, Integer> result = app.acceptList(Arrays.asList(1, 2, 3, 4, 5));
+        assertEquals(5, result.get("size").intValue());
     }
 }

--- a/ext/microprofile/pom.xml
+++ b/ext/microprofile/pom.xml
@@ -9,7 +9,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>jersey-microprofile</artifactId>
+    <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+    <artifactId>project</artifactId>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This is based off release commit, so that the client can be yet added without need for releasing entire jersey project. In upstream the client changed its groupId, therefore only one released artifact changes - the bom.