### PR TITLE
PAYARA-3908: Prevent CDI components being used twice

### DIFF
--- a/containers/jdk-http/pom.xml
+++ b/containers/jdk-http/pom.xml
@@ -84,6 +84,7 @@
         <profile>
             <id>windows</id>
             <activation>
+                <jdk>1.8</jdk>
                 <os>
                     <family>windows</family>
                 </os>

--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,6 +55,7 @@ import org.glassfish.jersey.spi.Contract;
  *
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Miroslav Fuksa
+ * @author Patrik Dudits
  */
 public final class Providers {
 
@@ -278,7 +280,7 @@ public final class Providers {
         List<ServiceHolder<T>> providers = getServiceHolders(injectionManager,
                                                              contract,
                                                              CustomAnnotationLiteral.INSTANCE);
-        providers.addAll(getServiceHolders(injectionManager, contract));
+        providers.addAll(getServiceHolders(injectionManager, contract, Comparator.comparingInt(Providers::getPriority)));
         providers.sort((o1, o2) -> Comparator.comparingInt(Providers::getPriority).compare(
                 o1.getInstance().getClass(), o2.getInstance().getClass()));
 

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -104,6 +104,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * serves as a {@link Extension CDI Extension}, that intercepts CDI injection targets.
  *
  * @author Jakub Podlesak (jakub.podlesak at oracle.com)
+ * @author Patrik Dudits
  */
 @Priority(200)
 public class CdiComponentProvider implements ComponentProvider, Extension {
@@ -311,7 +312,7 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
                 : new GenericCdiBeanSupplier(clazz, injectionManager, beanManager, isCdiManaged);
 
         SupplierInstanceBinding<AbstractCdiBeanSupplier> builder = Bindings.supplier(beanFactory)
-                .to(clazz).qualifiedBy(CustomAnnotationLiteral.INSTANCE);
+                .to(clazz);
         for (final Class contract : providerContracts) {
             builder.to(contract);
         }

--- a/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/MainApplication.java
+++ b/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/MainApplication.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,6 +37,7 @@ import javax.ws.rs.core.Application;
  * JAX-RS application to configure resources.
  *
  * @author Jonathan Benoit (jonathan.benoit at oracle.com)
+ * @author Patrik Dudits
  */
 @ApplicationPath("main")
 @ApplicationScoped
@@ -66,6 +68,7 @@ public class MainApplication extends Application {
         classes.add(ConstructorInjectedResource.class);
         classes.add(ProducerResource.class);
         classes.add(FirstNonJaxRsBeanInjectedResource.class);
+        classes.add(ResponseFilter.class);
         return classes;
     }
 

--- a/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/ResponseFilter.java
+++ b/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/ResponseFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * CDI Managed response filter that should add single HTTP header.
+ * @author Patrik Dudits
+ */
+public class ResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add("Filter-Invoked", UUID.randomUUID().toString());
+    }
+}

--- a/tests/integration/cdi-test-webapp/src/test/java/org/glassfish/jersey/tests/cdi/resources/PerRequestBeanTest.java
+++ b/tests/integration/cdi-test-webapp/src/test/java/org/glassfish/jersey/tests/cdi/resources/PerRequestBeanTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,17 +21,22 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 /**
  * Test for the request scoped resource.
  *
  * @author Jakub Podlesak (jakub.podlesak at oracle.com)
+ * @author Patrik Dudits
  */
 @RunWith(Parameterized.class)
 public class PerRequestBeanTest extends CdiTest {
@@ -66,4 +72,18 @@ public class PerRequestBeanTest extends CdiTest {
         assertThat(s, containsString(target.getUri().toString()));
         assertThat(s, containsString(String.format("queryParam=%s", x)));
     }
+
+    @Test
+    public void testSingleResponseFilterInvocation() {
+
+        final WebTarget target = target().path("jcdibean/per-request").queryParam("x", x);
+
+        Response response = target.request().get();
+
+        List<Object> invocationIds = response.getHeaders().get("Filter-Invoked");
+
+        assertNotNull("Filter-Invoked header should be set by ResponseFilter", invocationIds);
+        assertEquals("ResponseFilter should be invoked only once", 1, invocationIds.size());
+    }
+
 }


### PR DESCRIPTION
This is cherrypick combining the upstream PRs I sent. All CDI-dependent tests pass.