### PR TITLE
PAYARA-4000 A REST management DELETE command returns 415 code instead of 404

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
@@ -53,9 +53,12 @@ public final class FormMultivaluedMapProvider extends AbstractFormProvider<Multi
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        // Only allow types MultivaluedMap<String, String> and MultivaluedMap.
-        return type == MultivaluedMap.class
-                && (type == genericType || mapType.equals(genericType));
+        if(type == MultivaluedMap.class || mapType.equals(genericType)){
+            return true;
+        }else if("java.util.Map".equals(type.getName()) || "java.util.Map".equals(genericType.getClass().getName())){
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import java.util.Map;
 
 import javax.inject.Singleton;
 
@@ -53,12 +54,8 @@ public final class FormMultivaluedMapProvider extends AbstractFormProvider<Multi
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        if(type == MultivaluedMap.class || mapType.equals(genericType)){
-            return true;
-        }else if("java.util.Map".equals(type.getName()) || "java.util.Map".equals(genericType.getClass().getName())){
-            return true;
-        }
-        return false;
+        return (type == MultivaluedMap.class && (type == genericType || mapType.equals(genericType))) 
+                || (type == Map.class || genericType == Map.class);
     }
 
     @Override

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/FormMultivaluedMapProvider.java
@@ -54,8 +54,11 @@ public final class FormMultivaluedMapProvider extends AbstractFormProvider<Multi
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return (type == MultivaluedMap.class && (type == genericType || mapType.equals(genericType))) 
-                || (type == Map.class || genericType == Map.class);
+        return (type == MultivaluedMap.class 
+                && (type == genericType 
+                || mapType.equals(genericType))) 
+                || (type.isAssignableFrom(MultivaluedMap.class)
+                && mediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE));
     }
 
     @Override

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.crypto.AEADBadTagException;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.InternalServerErrorException;

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -259,7 +259,7 @@ public class ServerRuntime {
                     } else {
                         externalRequestScope.suspend(asyncResponderHolder.externalContext, injectionManager);
                     } 
-                } catch (NotFoundException throwable) {
+                } catch (final NotFoundException throwable) {
                     responder.process(throwable);
                 } finally {
                     asyncResponderHolder.release();

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -401,7 +401,7 @@ public class ServerRuntime {
             processingContext.triggerEvent(RequestEvent.Type.ON_EXCEPTION);
 
             ContainerResponse response = null;
-                    try {
+            try {
                 final Response exceptionResponse = mapException(throwable);
                 try {
                     try {

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.crypto.AEADBadTagException;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.InternalServerErrorException;
@@ -51,6 +52,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import javax.inject.Provider;
+import javax.ws.rs.NotSupportedException;
 
 import org.glassfish.jersey.internal.guava.Preconditions;
 import org.glassfish.jersey.internal.inject.InjectionManager;
@@ -256,8 +258,8 @@ public class ServerRuntime {
                         responder.process(response);
                     } else {
                         externalRequestScope.suspend(asyncResponderHolder.externalContext, injectionManager);
-                    }
-                } catch (final Throwable throwable) {
+                    } 
+                } catch (NotFoundException throwable) {
                     responder.process(throwable);
                 } finally {
                     asyncResponderHolder.release();
@@ -399,7 +401,7 @@ public class ServerRuntime {
             processingContext.triggerEvent(RequestEvent.Type.ON_EXCEPTION);
 
             ContainerResponse response = null;
-            try {
+                    try {
                 final Response exceptionResponse = mapException(throwable);
                 try {
                     try {

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/MappableExceptionWrapperInterceptor.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/MappableExceptionWrapperInterceptor.java
@@ -27,7 +27,6 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 
 import javax.annotation.Priority;
 import javax.inject.Singleton;
-import javax.ws.rs.NotFoundException;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException;

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/MappableExceptionWrapperInterceptor.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/MappableExceptionWrapperInterceptor.java
@@ -27,6 +27,7 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 
 import javax.annotation.Priority;
 import javax.inject.Singleton;
+import javax.ws.rs.NotFoundException;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException;

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodInvoker.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodInvoker.java
@@ -389,7 +389,7 @@ public class ResourceMethodInvoker implements Endpoint, ResourceInfo {
         } else {
             // TODO replace with processing context factory method.
             Response response = invoke(processingContext, resource);
-
+            
             // we don't care about the response when SseEventSink is injected - it will be sent asynchronously.
             if (method.isSse()) {
                 return null;
@@ -477,7 +477,7 @@ public class ResourceMethodInvoker implements Endpoint, ResourceInfo {
 
         return jaxrsResponse;
     }
-
+    
     /**
      * Get all bound request filters applicable to the {@link #getResourceMethod() resource method}
      * wrapped by this invoker.

--- a/core-server/src/main/java/org/glassfish/jersey/server/spi/internal/ParameterValueHelper.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/spi/internal/ParameterValueHelper.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
 
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.ProcessingException;
@@ -72,7 +73,7 @@ public final class ParameterValueHelper {
         } catch (WebApplicationException e) {
             throw e;
         } catch (MessageBodyProviderNotFoundException e) {
-            throw new NotSupportedException(e);
+            throw new NotFoundException(e);
         } catch (ProcessingException e) {
             throw e;
         } catch (RuntimeException e) {


### PR DESCRIPTION
Ondrej identified the issue being that the bodyReader value in ReaderInterceptorExecutor on Line 203 returns null, whereas in previous versions the bodyreader is not null, this additional check fixes that and bodyReader now has a value as url encoded forms are supported, so now if it cannot find a bodyReader it will return a 404 instead of a 415.