### PR TITLE
Fix AnnotatedClassVisitor using old ASM version

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/AnnotationAcceptingListener.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/AnnotationAcceptingListener.java
@@ -164,7 +164,7 @@ public final class AnnotationAcceptingListener implements ResourceProcessor {
         private boolean isAnnotated;
 
         private AnnotatedClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         public void visit(final int version, final int access, final String name,


### PR DESCRIPTION
This PR fixes payara/Payara#4046 (PAYARA-3959)

As per the linked issue, some Java 11 applications could not be deployed on Payara Server 5.192 (and 5.193) due to an internal JAX-RS implementation error. After some debugging, I found out that the patched build of Jersey used in Payara was still requesting behaviour from an old version of the ASM library, which has been [fixed in the upstream project](https://github.com/eclipse-ee4j/jersey/blob/master/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/AnnotationAcceptingListener.java#L169), but not here. 

The table below contains the results of testing with a clean, unmodified version of Payara Server 5.193 (fix applied = no), and the same build of Payara but with the jersey-server.jar module replaced with one built with this patch (fix applied = yes). All of the test cases were run with the provided test case from [the linked issue](https://github.com/payara/Payara/issues/4046#issuecomment-502719124) and with one of our Java EE applications, with the generated and osgi-cache folders cleaned between each scenario. As such, we didn't find any immediate regressions.

Fix applied | Server JDK | WAR JDK target | Deploys successfully?
---:|---:|---:|---
no  | 8  | 8  | yes
no  | 11 | 8  | yes
no  | 11 | 11 | **no** (UnsupportedOperationException)
yes | 8  | 8  | yes
yes | 11 | 8  | yes
yes | 11 | 11 | **yes**