### PR TITLE
Fix BOM version on maintenance branch

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.jersey</groupId>
     <artifactId>jersey-bom</artifactId>
-    <version>2.29.1</version>
+    <version>2.29.1.payara-p1</version>
     <packaging>pom</packaging>
     <name>jersey-bom</name>
 


### PR DESCRIPTION
Somehow not even `-DprocessAllModules` for `mvn versions:set` reached into BOM this time.