### PR TITLE
CUSTCOM-11 Prevent Parsing Null JSON Entities

### DIFF
--- a/archetypes/jersey-example-java8-webapp/pom.xml
+++ b/archetypes/jersey-example-java8-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.archetypes</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-example-java8-webapp</artifactId>

--- a/archetypes/jersey-heroku-webapp/pom.xml
+++ b/archetypes/jersey-heroku-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.archetypes</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <packaging>maven-archetype</packaging>
 

--- a/archetypes/jersey-quickstart-grizzly2/pom.xml
+++ b/archetypes/jersey-quickstart-grizzly2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.jersey.archetypes</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <artifactId>jersey-quickstart-grizzly2</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/jersey-quickstart-webapp/pom.xml
+++ b/archetypes/jersey-quickstart-webapp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.jersey.archetypes</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-archetype</packaging>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.archetypes</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.jersey</groupId>
     <artifactId>jersey-bom</artifactId>
-    <version>2.29.1.payara-p1</version>
+    <version>2.29.1.payara-p2</version>
     <packaging>pom</packaging>
     <name>jersey-bom</name>
 

--- a/bundles/apidocs/pom.xml
+++ b/bundles/apidocs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.bundles</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>apidocs</artifactId>

--- a/bundles/examples/pom.xml
+++ b/bundles/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.bundles</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-examples</artifactId>

--- a/bundles/jaxrs-ri/pom.xml
+++ b/bundles/jaxrs-ri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.bundles</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jaxrs-ri</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.bundles</groupId>

--- a/connectors/apache-connector/pom.xml
+++ b/connectors/apache-connector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-apache-connector</artifactId>

--- a/connectors/grizzly-connector/pom.xml
+++ b/connectors/grizzly-connector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-grizzly-connector</artifactId>

--- a/connectors/jdk-connector/pom.xml
+++ b/connectors/jdk-connector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-jdk-connector</artifactId>

--- a/connectors/jetty-connector/pom.xml
+++ b/connectors/jetty-connector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-jetty-connector</artifactId>

--- a/connectors/netty-connector/pom.xml
+++ b/connectors/netty-connector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.connectors</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-netty-connector</artifactId>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.connectors</groupId>

--- a/containers/glassfish/jersey-gf-ejb/pom.xml
+++ b/containers/glassfish/jersey-gf-ejb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers.glassfish</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-gf-ejb</artifactId>

--- a/containers/glassfish/pom.xml
+++ b/containers/glassfish/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.containers.glassfish</groupId>

--- a/containers/grizzly2-http/pom.xml
+++ b/containers/grizzly2-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-grizzly2-http</artifactId>

--- a/containers/grizzly2-servlet/pom.xml
+++ b/containers/grizzly2-servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-grizzly2-servlet</artifactId>

--- a/containers/jdk-http/pom.xml
+++ b/containers/jdk-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-jdk-http</artifactId>

--- a/containers/jersey-servlet-core/pom.xml
+++ b/containers/jersey-servlet-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-servlet-core</artifactId>

--- a/containers/jersey-servlet/pom.xml
+++ b/containers/jersey-servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-servlet</artifactId>

--- a/containers/jetty-http/pom.xml
+++ b/containers/jetty-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.containers</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-jetty-http</artifactId>

--- a/containers/jetty-servlet/pom.xml
+++ b/containers/jetty-servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-jetty-servlet</artifactId>

--- a/containers/netty-http/pom.xml
+++ b/containers/netty-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-netty-http</artifactId>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.containers</groupId>

--- a/containers/simple-http/pom.xml
+++ b/containers/simple-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-container-simple-http</artifactId>

--- a/core-client/pom.xml
+++ b/core-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.core</groupId>

--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.core</groupId>

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderInterceptorExecutor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderInterceptorExecutor.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates and others.
- * All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,9 +12,6 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- *
- * Contributors:
- *  Payara Services - Prevent parsing in case of null entity
  */
 
 package org.glassfish.jersey.message.internal;
@@ -194,24 +190,24 @@ public final class ReaderInterceptorExecutor extends InterceptorExecutor<ReaderI
                             String.valueOf(context.getMediaType()), java.util.Arrays.toString(context.getAnnotations()));
                 }
 
-                final EntityInputStream input = new EntityInputStream(context.getInputStream());
-
-                if (input.isEmpty()) {
-                    return null;
-                }
-
-                final MessageBodyReader<?> bodyReader = workers.getMessageBodyReader(
+                final MessageBodyReader bodyReader = workers.getMessageBodyReader(
                         context.getType(),
                         context.getGenericType(),
                         context.getAnnotations(),
                         context.getMediaType(),
                         ReaderInterceptorExecutor.this);
 
+                final EntityInputStream input = new EntityInputStream(context.getInputStream());
+
                 if (bodyReader == null) {
-                    LOGGER.log(Level.FINE, LocalizationMessages.ERROR_NOTFOUND_MESSAGEBODYREADER(context.getMediaType(),
-                            context.getType(), context.getGenericType()));
-                    throw new MessageBodyProviderNotFoundException(LocalizationMessages.ERROR_NOTFOUND_MESSAGEBODYREADER(
-                            context.getMediaType(), context.getType(), context.getGenericType()));
+                    if (input.isEmpty() && !context.getHeaders().containsKey(HttpHeaders.CONTENT_TYPE)) {
+                        return null;
+                    } else {
+                        LOGGER.log(Level.FINE, LocalizationMessages.ERROR_NOTFOUND_MESSAGEBODYREADER(context.getMediaType(),
+                                context.getType(), context.getGenericType()));
+                        throw new MessageBodyProviderNotFoundException(LocalizationMessages.ERROR_NOTFOUND_MESSAGEBODYREADER(
+                                context.getMediaType(), context.getType(), context.getGenericType()));
+                    }
                 }
                 Object entity = invokeReadFrom(context, bodyReader, input);
 

--- a/core-server/pom.xml
+++ b/core-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.core</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <artifactId>jersey-documentation</artifactId>
     <packaging>pom</packaging>

--- a/examples/assemblies/pom.xml
+++ b/examples/assemblies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>assemblies</artifactId>

--- a/examples/bookmark-em/pom.xml
+++ b/examples/bookmark-em/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>bookmark-em</artifactId>

--- a/examples/bookmark/pom.xml
+++ b/examples/bookmark/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>bookmark</artifactId>

--- a/examples/bookstore-webapp/pom.xml
+++ b/examples/bookstore-webapp/pom.xml
@@ -35,7 +35,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>bookstore-webapp</artifactId>

--- a/examples/cdi-webapp/pom.xml
+++ b/examples/cdi-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-webapp</artifactId>

--- a/examples/clipboard-programmatic/pom.xml
+++ b/examples/clipboard-programmatic/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>clipboard-programmatic</artifactId>

--- a/examples/clipboard/pom.xml
+++ b/examples/clipboard/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>clipboard</artifactId>

--- a/examples/declarative-linking/pom.xml
+++ b/examples/declarative-linking/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>declarative-linking</artifactId>

--- a/examples/entity-filtering-security/pom.xml
+++ b/examples/entity-filtering-security/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>entity-filtering-security</artifactId>

--- a/examples/entity-filtering-selectable/pom.xml
+++ b/examples/entity-filtering-selectable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>entity-filtering-selectable</artifactId>

--- a/examples/entity-filtering/pom.xml
+++ b/examples/entity-filtering/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>entity-filtering</artifactId>

--- a/examples/exception-mapping/pom.xml
+++ b/examples/exception-mapping/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>exception-mapping</artifactId>

--- a/examples/extended-wadl-webapp/pom.xml
+++ b/examples/extended-wadl-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>extended-wadl-webapp</artifactId>

--- a/examples/freemarker-webapp/pom.xml
+++ b/examples/freemarker-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>freemarker-webapp</artifactId>

--- a/examples/groovy/pom.xml
+++ b/examples/groovy/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <artifactId>groovy</artifactId>
     <packaging>jar</packaging>

--- a/examples/helloworld-benchmark/pom.xml
+++ b/examples/helloworld-benchmark/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-benchmark</artifactId>

--- a/examples/helloworld-cdi2-se/pom.xml
+++ b/examples/helloworld-cdi2-se/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-cdi2-se</artifactId>

--- a/examples/helloworld-netty/pom.xml
+++ b/examples/helloworld-netty/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-netty</artifactId>

--- a/examples/helloworld-programmatic/pom.xml
+++ b/examples/helloworld-programmatic/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-programmatic</artifactId>

--- a/examples/helloworld-pure-jax-rs/pom.xml
+++ b/examples/helloworld-pure-jax-rs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-pure-jax-rs</artifactId>

--- a/examples/helloworld-spring-annotations/pom.xml
+++ b/examples/helloworld-spring-annotations/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.examples</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helloworld-spring-annotations</artifactId>

--- a/examples/helloworld-spring-webapp/pom.xml
+++ b/examples/helloworld-spring-webapp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-spring-webapp</artifactId>

--- a/examples/helloworld-webapp/pom.xml
+++ b/examples/helloworld-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-webapp</artifactId>

--- a/examples/helloworld-weld/pom.xml
+++ b/examples/helloworld-weld/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld-weld</artifactId>

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>helloworld</artifactId>

--- a/examples/http-patch/pom.xml
+++ b/examples/http-patch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>http-patch</artifactId>

--- a/examples/http-trace/pom.xml
+++ b/examples/http-trace/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>http-trace</artifactId>

--- a/examples/https-clientserver-grizzly/pom.xml
+++ b/examples/https-clientserver-grizzly/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>https-clientserver-grizzly</artifactId>

--- a/examples/https-server-glassfish/pom.xml
+++ b/examples/https-server-glassfish/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>https-server-glassfish</artifactId>

--- a/examples/java8-webapp/pom.xml
+++ b/examples/java8-webapp/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>java8-webapp</artifactId>

--- a/examples/jaxb/pom.xml
+++ b/examples/jaxb/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jaxb</artifactId>

--- a/examples/jaxrs-types-injection/pom.xml
+++ b/examples/jaxrs-types-injection/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jaxrs-types-injection</artifactId>

--- a/examples/jersey-ejb/pom.xml
+++ b/examples/jersey-ejb/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-ejb</artifactId>

--- a/examples/json-binding-webapp/pom.xml
+++ b/examples/json-binding-webapp/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-binding-webapp</artifactId>

--- a/examples/json-jackson/pom.xml
+++ b/examples/json-jackson/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-jackson</artifactId>

--- a/examples/json-jackson1/pom.xml
+++ b/examples/json-jackson1/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-jackson1</artifactId>

--- a/examples/json-jettison/pom.xml
+++ b/examples/json-jettison/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-jettison</artifactId>

--- a/examples/json-moxy/pom.xml
+++ b/examples/json-moxy/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-moxy</artifactId>

--- a/examples/json-processing-webapp/pom.xml
+++ b/examples/json-processing-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-processing-webapp</artifactId>

--- a/examples/json-with-padding/pom.xml
+++ b/examples/json-with-padding/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-with-padding</artifactId>

--- a/examples/managed-beans-webapp/pom.xml
+++ b/examples/managed-beans-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>managed-beans-webapp</artifactId>

--- a/examples/managed-client-simple-webapp/pom.xml
+++ b/examples/managed-client-simple-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>managed-client-simple-webapp</artifactId>

--- a/examples/managed-client-webapp/pom.xml
+++ b/examples/managed-client-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>managed-client-webapp</artifactId>

--- a/examples/managed-client/pom.xml
+++ b/examples/managed-client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>managed-client</artifactId>

--- a/examples/multipart-webapp/pom.xml
+++ b/examples/multipart-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>multipart-webapp</artifactId>

--- a/examples/oauth-client-twitter/pom.xml
+++ b/examples/oauth-client-twitter/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.examples</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/open-tracing/pom.xml
+++ b/examples/open-tracing/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>open-tracing</artifactId>

--- a/examples/osgi-helloworld-webapp/additional-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/additional-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-helloworld-webapp</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-helloworld-webapp</groupId>

--- a/examples/osgi-helloworld-webapp/alternate-version-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/alternate-version-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-helloworld-webapp</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-helloworld-webapp</groupId>

--- a/examples/osgi-helloworld-webapp/functional-test/pom.xml
+++ b/examples/osgi-helloworld-webapp/functional-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-helloworld-webapp</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-helloworld-webapp</groupId>

--- a/examples/osgi-helloworld-webapp/lib-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/lib-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-helloworld-webapp</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-helloworld-webapp</groupId>

--- a/examples/osgi-helloworld-webapp/pom.xml
+++ b/examples/osgi-helloworld-webapp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>osgi-helloworld-webapp</artifactId>

--- a/examples/osgi-helloworld-webapp/war-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/war-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-helloworld-webapp</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-helloworld-webapp</groupId>

--- a/examples/osgi-http-service/bundle/pom.xml
+++ b/examples/osgi-http-service/bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-http-service</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-http-service</groupId>

--- a/examples/osgi-http-service/functional-test/pom.xml
+++ b/examples/osgi-http-service/functional-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>osgi-http-service</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.examples.osgi-http-service</groupId>

--- a/examples/osgi-http-service/pom.xml
+++ b/examples/osgi-http-service/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>osgi-http-service</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <licenses>

--- a/examples/reload/pom.xml
+++ b/examples/reload/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>reload</artifactId>

--- a/examples/rx-client-webapp/pom.xml
+++ b/examples/rx-client-webapp/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>rx-client-webapp</artifactId>

--- a/examples/server-async-managed/pom.xml
+++ b/examples/server-async-managed/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-async-managed</artifactId>

--- a/examples/server-async-standalone/client/pom.xml
+++ b/examples/server-async-standalone/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>server-async-standalone</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-async-standalone-client</artifactId>

--- a/examples/server-async-standalone/pom.xml
+++ b/examples/server-async-standalone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-async-standalone</artifactId>

--- a/examples/server-async-standalone/webapp/pom.xml
+++ b/examples/server-async-standalone/webapp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>server-async-standalone</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-async-standalone-webapp</artifactId>

--- a/examples/server-async/pom.xml
+++ b/examples/server-async/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-async</artifactId>

--- a/examples/server-sent-events-jaxrs/pom.xml
+++ b/examples/server-sent-events-jaxrs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-sent-events-jaxrs</artifactId>

--- a/examples/server-sent-events-jersey/pom.xml
+++ b/examples/server-sent-events-jersey/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>server-sent-events-jersey</artifactId>

--- a/examples/servlet3-webapp/pom.xml
+++ b/examples/servlet3-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet3-webapp</artifactId>

--- a/examples/simple-console/pom.xml
+++ b/examples/simple-console/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>simple-console</artifactId>

--- a/examples/sse-item-store-jaxrs-webapp/pom.xml
+++ b/examples/sse-item-store-jaxrs-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>sse-item-store-jaxrs-webapp</artifactId>

--- a/examples/sse-item-store-jersey-webapp/pom.xml
+++ b/examples/sse-item-store-jersey-webapp/pom.xml
@@ -19,7 +19,7 @@
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>webapp-example-parent</artifactId>
         <relativePath>../webapp-example-parent/pom.xml</relativePath>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>sse-item-store-jersey-webapp</artifactId>

--- a/examples/sse-twitter-aggregator/pom.xml
+++ b/examples/sse-twitter-aggregator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>sse-twitter-aggregator</artifactId>

--- a/examples/system-properties-example/pom.xml
+++ b/examples/system-properties-example/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>system-properties-example</artifactId>

--- a/examples/webapp-example-parent/pom.xml
+++ b/examples/webapp-example-parent/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>webapp-example-parent</artifactId>

--- a/examples/xml-moxy/pom.xml
+++ b/examples/xml-moxy/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jersey.examples</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>xml-moxy</artifactId>

--- a/ext/bean-validation/pom.xml
+++ b/ext/bean-validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-bean-validation</artifactId>

--- a/ext/cdi/jersey-cdi1x-ban-custom-hk2-binding/pom.xml
+++ b/ext/cdi/jersey-cdi1x-ban-custom-hk2-binding/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi1x-ban-custom-hk2-binding</artifactId>

--- a/ext/cdi/jersey-cdi1x-servlet/pom.xml
+++ b/ext/cdi/jersey-cdi1x-servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi1x-servlet</artifactId>

--- a/ext/cdi/jersey-cdi1x-transaction/pom.xml
+++ b/ext/cdi/jersey-cdi1x-transaction/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi1x-transaction</artifactId>

--- a/ext/cdi/jersey-cdi1x-validation/pom.xml
+++ b/ext/cdi/jersey-cdi1x-validation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi1x-validation</artifactId>

--- a/ext/cdi/jersey-cdi1x/pom.xml
+++ b/ext/cdi/jersey-cdi1x/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi1x</artifactId>

--- a/ext/cdi/jersey-weld2-se/pom.xml
+++ b/ext/cdi/jersey-weld2-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.cdi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-weld2-se</artifactId>

--- a/ext/cdi/pom.xml
+++ b/ext/cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.ext.cdi</groupId>

--- a/ext/entity-filtering/pom.xml
+++ b/ext/entity-filtering/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-entity-filtering</artifactId>

--- a/ext/metainf-services/pom.xml
+++ b/ext/metainf-services/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-metainf-services</artifactId>

--- a/ext/microprofile/mp-config/pom.xml
+++ b/ext/microprofile/mp-config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.ext.microprofile</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.ext.microprofile</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ext/microprofile/pom.xml
+++ b/ext/microprofile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.ext</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ext/mvc-bean-validation/pom.xml
+++ b/ext/mvc-bean-validation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-mvc-bean-validation</artifactId>

--- a/ext/mvc-freemarker/pom.xml
+++ b/ext/mvc-freemarker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-mvc-freemarker</artifactId>

--- a/ext/mvc-jsp/pom.xml
+++ b/ext/mvc-jsp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-mvc-jsp</artifactId>

--- a/ext/mvc-mustache/pom.xml
+++ b/ext/mvc-mustache/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-mvc-mustache</artifactId>

--- a/ext/mvc/pom.xml
+++ b/ext/mvc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-mvc</artifactId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.ext</groupId>

--- a/ext/proxy-client/pom.xml
+++ b/ext/proxy-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-proxy-client</artifactId>

--- a/ext/rx/pom.xml
+++ b/ext/rx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.ext.rx</groupId>

--- a/ext/rx/rx-client-guava/pom.xml
+++ b/ext/rx/rx-client-guava/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.rx</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-rx-client-guava</artifactId>

--- a/ext/rx/rx-client-rxjava/pom.xml
+++ b/ext/rx/rx-client-rxjava/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.rx</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-rx-client-rxjava</artifactId>

--- a/ext/rx/rx-client-rxjava2/pom.xml
+++ b/ext/rx/rx-client-rxjava2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext.rx</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-rx-client-rxjava2</artifactId>

--- a/ext/servlet-portability/pom.xml
+++ b/ext/servlet-portability/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.ext</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-servlet-portability</artifactId>

--- a/ext/spring4/pom.xml
+++ b/ext/spring4/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-spring4</artifactId>

--- a/ext/spring5/pom.xml
+++ b/ext/spring5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-spring5</artifactId>

--- a/ext/wadl-doclet/pom.xml
+++ b/ext/wadl-doclet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.ext</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jersey-wadl-doclet</artifactId>

--- a/incubator/declarative-linking/pom.xml
+++ b/incubator/declarative-linking/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.ext</groupId>

--- a/incubator/gae-integration/pom.xml
+++ b/incubator/gae-integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-gae-integration</artifactId>

--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>

--- a/incubator/kryo/pom.xml
+++ b/incubator/kryo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>

--- a/incubator/open-tracing/pom.xml
+++ b/incubator/open-tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.incubator</groupId>

--- a/incubator/pom.xml
+++ b/incubator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.incubator</groupId>

--- a/inject/cdi2-se/pom.xml
+++ b/inject/cdi2-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-cdi2-se</artifactId>

--- a/inject/hk2/pom.xml
+++ b/inject/hk2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-hk2</artifactId>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.inject</groupId>

--- a/media/jaxb/pom.xml
+++ b/media/jaxb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-jaxb</artifactId>

--- a/media/json-binding/pom.xml
+++ b/media/json-binding/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-json-binding</artifactId>

--- a/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingProvider.java
+++ b/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingProvider.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,6 +13,9 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *
+ * Contributors:
+ *  Payara Services - Prevent parsing null streams
  */
 
 package org.glassfish.jersey.jsonb.internal;
@@ -70,6 +74,9 @@ public class JsonBindingProvider extends AbstractMessageReaderWriterProvider<Obj
                            MediaType mediaType,
                            MultivaluedMap<String, String> httpHeaders,
                            InputStream entityStream) throws IOException, WebApplicationException {
+        if (entityStream.available() == 0) {
+            return null;
+        }
         Jsonb jsonb = getJsonb(type);
         try {
             return jsonb.fromJson(entityStream, genericType);

--- a/media/json-jackson/pom.xml
+++ b/media/json-jackson/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-json-jackson</artifactId>

--- a/media/json-jackson1/pom.xml
+++ b/media/json-jackson1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-json-jackson1</artifactId>

--- a/media/json-jettison/pom.xml
+++ b/media/json-jettison/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-json-jettison</artifactId>

--- a/media/json-processing/pom.xml
+++ b/media/json-processing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-json-processing</artifactId>

--- a/media/moxy/pom.xml
+++ b/media/moxy/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-moxy</artifactId>

--- a/media/multipart/pom.xml
+++ b/media/multipart/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-multipart</artifactId>

--- a/media/pom.xml
+++ b/media/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>

--- a/media/sse/pom.xml
+++ b/media/sse/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-media-sse</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.glassfish.jersey</groupId>
     <artifactId>project</artifactId>
     <packaging>pom</packaging>
-    <version>2.29.1.payara-p1</version>
+    <version>2.29.1.payara-p2</version>
     <name>jersey</name>
     <description>
         Eclipse Jersey is the open source (under dual EPL+GPL license) JAX-RS 2.1 (JSR 370)

--- a/security/oauth1-client/pom.xml
+++ b/security/oauth1-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.security</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>oauth1-client</artifactId>

--- a/security/oauth1-server/pom.xml
+++ b/security/oauth1-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.security</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>oauth1-server</artifactId>

--- a/security/oauth1-signature/pom.xml
+++ b/security/oauth1-signature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.jersey.security</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/security/oauth2-client/pom.xml
+++ b/security/oauth2-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.jersey.security</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.security</groupId>

--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-core</artifactId>

--- a/test-framework/maven/container-runner-maven-plugin/pom.xml
+++ b/test-framework/maven/container-runner-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.maven</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>container-runner-maven-plugin</artifactId>

--- a/test-framework/maven/custom-enforcer-rules/pom.xml
+++ b/test-framework/maven/custom-enforcer-rules/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.maven</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>custom-enforcer-rules</artifactId>

--- a/test-framework/maven/pom.xml
+++ b/test-framework/maven/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.test-framework.maven</groupId>

--- a/test-framework/memleak-test-common/pom.xml
+++ b/test-framework/memleak-test-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>memleak-test-common</artifactId>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.test-framework</groupId>

--- a/test-framework/providers/bundle/pom.xml
+++ b/test-framework/providers/bundle/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-bundle</artifactId>

--- a/test-framework/providers/external/pom.xml
+++ b/test-framework/providers/external/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-external</artifactId>

--- a/test-framework/providers/grizzly2/pom.xml
+++ b/test-framework/providers/grizzly2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-grizzly2</artifactId>

--- a/test-framework/providers/inmemory/pom.xml
+++ b/test-framework/providers/inmemory/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-inmemory</artifactId>

--- a/test-framework/providers/jdk-http/pom.xml
+++ b/test-framework/providers/jdk-http/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-jdk-http</artifactId>

--- a/test-framework/providers/jetty/pom.xml
+++ b/test-framework/providers/jetty/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-framework/providers/netty/pom.xml
+++ b/test-framework/providers/netty/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-provider-netty</artifactId>

--- a/test-framework/providers/pom.xml
+++ b/test-framework/providers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/test-framework/providers/simple/pom.xml
+++ b/test-framework/providers/simple/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-framework/util/pom.xml
+++ b/test-framework/util/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.test-framework</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-test-framework-util</artifactId>

--- a/tests/e2e-client/pom.xml
+++ b/tests/e2e-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-client</artifactId>

--- a/tests/e2e-core-common/pom.xml
+++ b/tests/e2e-core-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-core-common</artifactId>

--- a/tests/e2e-entity/pom.xml
+++ b/tests/e2e-entity/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-entity</artifactId>

--- a/tests/e2e-inject/cdi2-se/pom.xml
+++ b/tests/e2e-inject/cdi2-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>e2e-inject</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-inject-cdi2-se</artifactId>

--- a/tests/e2e-inject/hk2/pom.xml
+++ b/tests/e2e-inject/hk2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>e2e-inject</artifactId>
         <groupId>org.glassfish.jersey.tests</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/e2e-inject/pom.xml
+++ b/tests/e2e-inject/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-inject</artifactId>

--- a/tests/e2e-server/pom.xml
+++ b/tests/e2e-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-server</artifactId>

--- a/tests/e2e-testng/pom.xml
+++ b/tests/e2e-testng/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e-testng</artifactId>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>e2e</artifactId>

--- a/tests/integration/asm/pom.xml
+++ b/tests/integration/asm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/async-jersey-filter/pom.xml
+++ b/tests/integration/async-jersey-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>async-jersey-filter</artifactId>

--- a/tests/integration/cdi-beanvalidation-webapp/pom.xml
+++ b/tests/integration/cdi-beanvalidation-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-beanvalidation-webapp</artifactId>

--- a/tests/integration/cdi-ejb-test-webapp/pom.xml
+++ b/tests/integration/cdi-ejb-test-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-ejb-test-webapp</artifactId>

--- a/tests/integration/cdi-iface-with-non-jaxrs-impl-test-webapp/pom.xml
+++ b/tests/integration/cdi-iface-with-non-jaxrs-impl-test-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-iface-with-non-jaxrs-impl-test-webapp</artifactId>

--- a/tests/integration/cdi-log-check/pom.xml
+++ b/tests/integration/cdi-log-check/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-log-check</artifactId>

--- a/tests/integration/cdi-multimodule/ear/pom.xml
+++ b/tests/integration/cdi-multimodule/ear/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/cdi-multimodule/lib/pom.xml
+++ b/tests/integration/cdi-multimodule/lib/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/cdi-multimodule/pom.xml
+++ b/tests/integration/cdi-multimodule/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-multimodule</artifactId>

--- a/tests/integration/cdi-multimodule/war1/pom.xml
+++ b/tests/integration/cdi-multimodule/war1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/cdi-multimodule/war2/pom.xml
+++ b/tests/integration/cdi-multimodule/war2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/cdi-multipart-webapp/pom.xml
+++ b/tests/integration/cdi-multipart-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-multipart-webapp</artifactId>

--- a/tests/integration/cdi-test-webapp/pom.xml
+++ b/tests/integration/cdi-test-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-test-webapp</artifactId>

--- a/tests/integration/cdi-with-jersey-injection-custom-cfg-webapp/pom.xml
+++ b/tests/integration/cdi-with-jersey-injection-custom-cfg-webapp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-with-jersey-injection-custom-cfg-webapp</artifactId>

--- a/tests/integration/cdi-with-jersey-injection-custom-hk2-banned-webapp/pom.xml
+++ b/tests/integration/cdi-with-jersey-injection-custom-hk2-banned-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-with-jersey-injection-custom-hk2-banned-webapp</artifactId>

--- a/tests/integration/cdi-with-jersey-injection-webapp/pom.xml
+++ b/tests/integration/cdi-with-jersey-injection-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>cdi-with-jersey-injection-webapp</artifactId>

--- a/tests/integration/client-connector-provider/pom.xml
+++ b/tests/integration/client-connector-provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>client-connector-provider</artifactId>

--- a/tests/integration/ejb-multimodule-reload/ear/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/ear/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule-reload/lib/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/lib/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule-reload/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>ejb-multimodule-reload</artifactId>

--- a/tests/integration/ejb-multimodule-reload/war1/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/war1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule-reload/war2/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/war2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule/ear/pom.xml
+++ b/tests/integration/ejb-multimodule/ear/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule/lib/pom.xml
+++ b/tests/integration/ejb-multimodule/lib/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-multimodule/pom.xml
+++ b/tests/integration/ejb-multimodule/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>ejb-multimodule</artifactId>

--- a/tests/integration/ejb-multimodule/war/pom.xml
+++ b/tests/integration/ejb-multimodule/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/ejb-test-webapp/pom.xml
+++ b/tests/integration/ejb-test-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>ejb-test-webapp</artifactId>

--- a/tests/integration/j-376/pom.xml
+++ b/tests/integration/j-376/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>j-376</artifactId>

--- a/tests/integration/j-441/ear/pom.xml
+++ b/tests/integration/j-441/ear/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>j-441-ear</artifactId>

--- a/tests/integration/j-441/pom.xml
+++ b/tests/integration/j-441/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>j-441</artifactId>

--- a/tests/integration/j-441/war1/pom.xml
+++ b/tests/integration/j-441/war1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/j-441/war2/pom.xml
+++ b/tests/integration/j-441/war2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/j-59/ear/pom.xml
+++ b/tests/integration/j-59/ear/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/j-59/lib/pom.xml
+++ b/tests/integration/j-59/lib/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/j-59/pom.xml
+++ b/tests/integration/j-59/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>j-59</artifactId>

--- a/tests/integration/j-59/war/pom.xml
+++ b/tests/integration/j-59/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/jaxrs-component-inject/pom.xml
+++ b/tests/integration/jaxrs-component-inject/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jaxrs-component-inject</artifactId>

--- a/tests/integration/jersey-1107/pom.xml
+++ b/tests/integration/jersey-1107/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-1107</artifactId>

--- a/tests/integration/jersey-1223/pom.xml
+++ b/tests/integration/jersey-1223/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jersey-1223</artifactId>

--- a/tests/integration/jersey-1604/pom.xml
+++ b/tests/integration/jersey-1604/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jersey-1604</artifactId>

--- a/tests/integration/jersey-1667/pom.xml
+++ b/tests/integration/jersey-1667/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-1667</artifactId>

--- a/tests/integration/jersey-1829/pom.xml
+++ b/tests/integration/jersey-1829/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jersey-1829</artifactId>

--- a/tests/integration/jersey-1883/pom.xml
+++ b/tests/integration/jersey-1883/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-1883</artifactId>

--- a/tests/integration/jersey-1928/pom.xml
+++ b/tests/integration/jersey-1928/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jersey-1928</artifactId>

--- a/tests/integration/jersey-1960/pom.xml
+++ b/tests/integration/jersey-1960/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-1960</artifactId>

--- a/tests/integration/jersey-1964/pom.xml
+++ b/tests/integration/jersey-1964/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-1964</artifactId>

--- a/tests/integration/jersey-2136/pom.xml
+++ b/tests/integration/jersey-2136/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2136</artifactId>

--- a/tests/integration/jersey-2137/pom.xml
+++ b/tests/integration/jersey-2137/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2137</artifactId>

--- a/tests/integration/jersey-2154/pom.xml
+++ b/tests/integration/jersey-2154/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2154</artifactId>

--- a/tests/integration/jersey-2160/pom.xml
+++ b/tests/integration/jersey-2160/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2160</artifactId>

--- a/tests/integration/jersey-2164/pom.xml
+++ b/tests/integration/jersey-2164/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2164</artifactId>

--- a/tests/integration/jersey-2167/pom.xml
+++ b/tests/integration/jersey-2167/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2167</artifactId>

--- a/tests/integration/jersey-2176/pom.xml
+++ b/tests/integration/jersey-2176/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2176</artifactId>

--- a/tests/integration/jersey-2184/pom.xml
+++ b/tests/integration/jersey-2184/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2184</artifactId>

--- a/tests/integration/jersey-2255/pom.xml
+++ b/tests/integration/jersey-2255/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2255</artifactId>

--- a/tests/integration/jersey-2322/pom.xml
+++ b/tests/integration/jersey-2322/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2322</artifactId>

--- a/tests/integration/jersey-2335/pom.xml
+++ b/tests/integration/jersey-2335/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2335</artifactId>

--- a/tests/integration/jersey-2421/pom.xml
+++ b/tests/integration/jersey-2421/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2421</artifactId>

--- a/tests/integration/jersey-2551/pom.xml
+++ b/tests/integration/jersey-2551/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2551</artifactId>

--- a/tests/integration/jersey-2612/pom.xml
+++ b/tests/integration/jersey-2612/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2612</artifactId>

--- a/tests/integration/jersey-2637/pom.xml
+++ b/tests/integration/jersey-2637/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2637</artifactId>

--- a/tests/integration/jersey-2654/pom.xml
+++ b/tests/integration/jersey-2654/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2654</artifactId>

--- a/tests/integration/jersey-2673/pom.xml
+++ b/tests/integration/jersey-2673/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2673</artifactId>

--- a/tests/integration/jersey-2689/pom.xml
+++ b/tests/integration/jersey-2689/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2689</artifactId>

--- a/tests/integration/jersey-2704/pom.xml
+++ b/tests/integration/jersey-2704/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2704</artifactId>

--- a/tests/integration/jersey-2776/pom.xml
+++ b/tests/integration/jersey-2776/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2776</artifactId>

--- a/tests/integration/jersey-2794/pom.xml
+++ b/tests/integration/jersey-2794/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2794</artifactId>

--- a/tests/integration/jersey-2846/pom.xml
+++ b/tests/integration/jersey-2846/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2846</artifactId>

--- a/tests/integration/jersey-2878/pom.xml
+++ b/tests/integration/jersey-2878/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2878</artifactId>

--- a/tests/integration/jersey-2892/pom.xml
+++ b/tests/integration/jersey-2892/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-2892</artifactId>

--- a/tests/integration/jersey-3670/pom.xml
+++ b/tests/integration/jersey-3670/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-3670</artifactId>

--- a/tests/integration/jersey-3796/pom.xml
+++ b/tests/integration/jersey-3796/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-3796</artifactId>

--- a/tests/integration/jersey-3992/pom.xml
+++ b/tests/integration/jersey-3992/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-3992</artifactId>

--- a/tests/integration/jersey-4099/pom.xml
+++ b/tests/integration/jersey-4099/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-4099</artifactId>

--- a/tests/integration/jersey-780/pom.xml
+++ b/tests/integration/jersey-780/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-780</artifactId>

--- a/tests/integration/microprofile/config/helidon/pom.xml
+++ b/tests/integration/microprofile/config/helidon/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/microprofile/config/webapp/pom.xml
+++ b/tests/integration/microprofile/config/webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/microprofile/rest-client/pom.xml
+++ b/tests/integration/microprofile/rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.integration</groupId>

--- a/tests/integration/portability-jersey-1/pom.xml
+++ b/tests/integration/portability-jersey-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>portability-jersey-1</artifactId>

--- a/tests/integration/portability-jersey-2/pom.xml
+++ b/tests/integration/portability-jersey-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>portability-jersey-2</artifactId>

--- a/tests/integration/property-check/pom.xml
+++ b/tests/integration/property-check/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>property-check</artifactId>

--- a/tests/integration/security-digest/pom.xml
+++ b/tests/integration/security-digest/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-digest</artifactId>

--- a/tests/integration/servlet-2.5-autodiscovery-1/pom.xml
+++ b/tests/integration/servlet-2.5-autodiscovery-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-autodiscovery-1</artifactId>

--- a/tests/integration/servlet-2.5-autodiscovery-2/pom.xml
+++ b/tests/integration/servlet-2.5-autodiscovery-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-autodiscovery-2</artifactId>

--- a/tests/integration/servlet-2.5-filter/pom.xml
+++ b/tests/integration/servlet-2.5-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-filter</artifactId>

--- a/tests/integration/servlet-2.5-inflector-1/pom.xml
+++ b/tests/integration/servlet-2.5-inflector-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-inflector-1</artifactId>

--- a/tests/integration/servlet-2.5-init-1/pom.xml
+++ b/tests/integration/servlet-2.5-init-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-1</artifactId>

--- a/tests/integration/servlet-2.5-init-2/pom.xml
+++ b/tests/integration/servlet-2.5-init-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-2</artifactId>

--- a/tests/integration/servlet-2.5-init-3/pom.xml
+++ b/tests/integration/servlet-2.5-init-3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-3</artifactId>

--- a/tests/integration/servlet-2.5-init-4/pom.xml
+++ b/tests/integration/servlet-2.5-init-4/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-4</artifactId>

--- a/tests/integration/servlet-2.5-init-5/pom.xml
+++ b/tests/integration/servlet-2.5-init-5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-5</artifactId>

--- a/tests/integration/servlet-2.5-init-6/pom.xml
+++ b/tests/integration/servlet-2.5-init-6/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-6</artifactId>

--- a/tests/integration/servlet-2.5-init-7/pom.xml
+++ b/tests/integration/servlet-2.5-init-7/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-7</artifactId>

--- a/tests/integration/servlet-2.5-init-8/pom.xml
+++ b/tests/integration/servlet-2.5-init-8/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-init-8</artifactId>

--- a/tests/integration/servlet-2.5-mvc-1/pom.xml
+++ b/tests/integration/servlet-2.5-mvc-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-mvc-1</artifactId>

--- a/tests/integration/servlet-2.5-mvc-2/pom.xml
+++ b/tests/integration/servlet-2.5-mvc-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-mvc-2</artifactId>

--- a/tests/integration/servlet-2.5-mvc-3/pom.xml
+++ b/tests/integration/servlet-2.5-mvc-3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-mvc-3</artifactId>

--- a/tests/integration/servlet-2.5-reload/pom.xml
+++ b/tests/integration/servlet-2.5-reload/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-2.5-reload</artifactId>

--- a/tests/integration/servlet-3-async/pom.xml
+++ b/tests/integration/servlet-3-async/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-async</artifactId>

--- a/tests/integration/servlet-3-chunked-io/pom.xml
+++ b/tests/integration/servlet-3-chunked-io/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-chunked-io</artifactId>

--- a/tests/integration/servlet-3-filter/pom.xml
+++ b/tests/integration/servlet-3-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-filter</artifactId>

--- a/tests/integration/servlet-3-gf-async/pom.xml
+++ b/tests/integration/servlet-3-gf-async/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-gf-async</artifactId>

--- a/tests/integration/servlet-3-inflector-1/pom.xml
+++ b/tests/integration/servlet-3-inflector-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-inflector-1</artifactId>

--- a/tests/integration/servlet-3-init-1/pom.xml
+++ b/tests/integration/servlet-3-init-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-1</artifactId>

--- a/tests/integration/servlet-3-init-2/pom.xml
+++ b/tests/integration/servlet-3-init-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-2</artifactId>

--- a/tests/integration/servlet-3-init-3/pom.xml
+++ b/tests/integration/servlet-3-init-3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-3</artifactId>

--- a/tests/integration/servlet-3-init-4/pom.xml
+++ b/tests/integration/servlet-3-init-4/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-4</artifactId>

--- a/tests/integration/servlet-3-init-5/pom.xml
+++ b/tests/integration/servlet-3-init-5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-5</artifactId>

--- a/tests/integration/servlet-3-init-6/pom.xml
+++ b/tests/integration/servlet-3-init-6/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-6</artifactId>

--- a/tests/integration/servlet-3-init-7/pom.xml
+++ b/tests/integration/servlet-3-init-7/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-7</artifactId>

--- a/tests/integration/servlet-3-init-8/pom.xml
+++ b/tests/integration/servlet-3-init-8/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-8</artifactId>

--- a/tests/integration/servlet-3-init-provider/pom.xml
+++ b/tests/integration/servlet-3-init-provider/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-init-provider</artifactId>

--- a/tests/integration/servlet-3-params/pom.xml
+++ b/tests/integration/servlet-3-params/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-params</artifactId>

--- a/tests/integration/servlet-3-sse-1/pom.xml
+++ b/tests/integration/servlet-3-sse-1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-3-sse-1</artifactId>

--- a/tests/integration/servlet-request-wrapper-binding-2/pom.xml
+++ b/tests/integration/servlet-request-wrapper-binding-2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-request-wrappper-binding-2</artifactId>

--- a/tests/integration/servlet-request-wrapper-binding/pom.xml
+++ b/tests/integration/servlet-request-wrapper-binding/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-request-wrappper-binding</artifactId>

--- a/tests/integration/servlet-tests/pom.xml
+++ b/tests/integration/servlet-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>servlet-tests</artifactId>

--- a/tests/integration/sonar-test/pom.xml
+++ b/tests/integration/sonar-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>sonar-test</artifactId>

--- a/tests/integration/spring4/pom.xml
+++ b/tests/integration/spring4/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>spring4</artifactId>

--- a/tests/integration/tracing-support/pom.xml
+++ b/tests/integration/tracing-support/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>tracing-support</artifactId>

--- a/tests/jmockit/pom.xml
+++ b/tests/jmockit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>project</artifactId>
         <groupId>org.glassfish.jersey.tests</groupId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/mem-leaks/pom.xml
+++ b/tests/mem-leaks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.memleaks</groupId>

--- a/tests/mem-leaks/redeployment/pom.xml
+++ b/tests/mem-leaks/redeployment/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.memleaks.redeployment</groupId>

--- a/tests/mem-leaks/redeployment/redeployment-hello-world-app-ref/pom.xml
+++ b/tests/mem-leaks/redeployment/redeployment-hello-world-app-ref/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.redeployment</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>redeployment-hello-world-app-ref</artifactId>
@@ -132,7 +132,7 @@
             <groupId>org.glassfish.jersey.examples</groupId>
             <artifactId>helloworld-webapp</artifactId>
             <type>war</type>
-            <version>2.29.1.payara-p1</version>
+            <version>2.29.1.payara-p2</version>
         </dependency>
     </dependencies>
 

--- a/tests/mem-leaks/redeployment/redeployment-leaking-test-app/pom.xml
+++ b/tests/mem-leaks/redeployment/redeployment-leaking-test-app/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.redeployment</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>redeployment-leaking-test-app</artifactId>

--- a/tests/mem-leaks/redeployment/redeployment-no-jersey-app/pom.xml
+++ b/tests/mem-leaks/redeployment/redeployment-no-jersey-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.redeployment</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>redeployment-no-jersey-app</artifactId>

--- a/tests/mem-leaks/redeployment/redeployment-threadlocals-app/pom.xml
+++ b/tests/mem-leaks/redeployment/redeployment-threadlocals-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.redeployment</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>redeployment-threadlocals-app</artifactId>

--- a/tests/mem-leaks/test-cases/bean-param-leak/pom.xml
+++ b/tests/mem-leaks/test-cases/bean-param-leak/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>bean-param-leak</artifactId>

--- a/tests/mem-leaks/test-cases/leaking-test-app/pom.xml
+++ b/tests/mem-leaks/test-cases/leaking-test-app/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>leaking-test-app</artifactId>

--- a/tests/mem-leaks/test-cases/pom.xml
+++ b/tests/mem-leaks/test-cases/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.memleaks.testcases</groupId>

--- a/tests/mem-leaks/test-cases/shutdown-hook-leak-client/pom.xml
+++ b/tests/mem-leaks/test-cases/shutdown-hook-leak-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>shutdown-hook-leak-client</artifactId>

--- a/tests/mem-leaks/test-cases/shutdown-hook-leak/pom.xml
+++ b/tests/mem-leaks/test-cases/shutdown-hook-leak/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.memleaks.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>shutdown-hook-leak</artifactId>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.osgi</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>jersey-tests-osgi-functional</artifactId>

--- a/tests/osgi/pom.xml
+++ b/tests/osgi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.osgi</groupId>

--- a/tests/performance/benchmarks/pom.xml
+++ b/tests/performance/benchmarks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>performance-test-benchmarks</artifactId>

--- a/tests/performance/pom.xml
+++ b/tests/performance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.performance</groupId>

--- a/tests/performance/runners/jersey-grizzly-runner/pom.xml
+++ b/tests/performance/runners/jersey-grizzly-runner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.runners</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
 

--- a/tests/performance/runners/pom.xml
+++ b/tests/performance/runners/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.performance.runners</groupId>

--- a/tests/performance/test-cases/assemblies/pom.xml
+++ b/tests/performance/test-cases/assemblies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>assemblies</artifactId>

--- a/tests/performance/test-cases/filter-dynamic/pom.xml
+++ b/tests/performance/test-cases/filter-dynamic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>filter-dynamic</artifactId>

--- a/tests/performance/test-cases/filter-global/pom.xml
+++ b/tests/performance/test-cases/filter-global/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>filter-global</artifactId>

--- a/tests/performance/test-cases/filter-name/pom.xml
+++ b/tests/performance/test-cases/filter-name/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>filter-name</artifactId>

--- a/tests/performance/test-cases/interceptor-dynamic/pom.xml
+++ b/tests/performance/test-cases/interceptor-dynamic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>interceptor-dynamic</artifactId>

--- a/tests/performance/test-cases/interceptor-global/pom.xml
+++ b/tests/performance/test-cases/interceptor-global/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>interceptor-global</artifactId>

--- a/tests/performance/test-cases/interceptor-name/pom.xml
+++ b/tests/performance/test-cases/interceptor-name/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>interceptor-name</artifactId>

--- a/tests/performance/test-cases/mbw-custom-provider/pom.xml
+++ b/tests/performance/test-cases/mbw-custom-provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>custom-provider</artifactId>

--- a/tests/performance/test-cases/mbw-json-jackson/pom.xml
+++ b/tests/performance/test-cases/mbw-json-jackson/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-jackson</artifactId>

--- a/tests/performance/test-cases/mbw-json-moxy/pom.xml
+++ b/tests/performance/test-cases/mbw-json-moxy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>json-moxy</artifactId>

--- a/tests/performance/test-cases/mbw-kryo/pom.xml
+++ b/tests/performance/test-cases/mbw-kryo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>mbw-kryo</artifactId>

--- a/tests/performance/test-cases/mbw-text-plain/pom.xml
+++ b/tests/performance/test-cases/mbw-text-plain/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>text-plain</artifactId>

--- a/tests/performance/test-cases/mbw-xml-jaxb/pom.xml
+++ b/tests/performance/test-cases/mbw-xml-jaxb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>xml-jaxb</artifactId>

--- a/tests/performance/test-cases/mbw-xml-moxy/pom.xml
+++ b/tests/performance/test-cases/mbw-xml-moxy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>xml-moxy</artifactId>

--- a/tests/performance/test-cases/param-srl/pom.xml
+++ b/tests/performance/test-cases/param-srl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>param-srl</artifactId>

--- a/tests/performance/test-cases/pom.xml
+++ b/tests/performance/test-cases/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>

--- a/tests/performance/test-cases/proxy-injection/pom.xml
+++ b/tests/performance/test-cases/proxy-injection/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance.testcases</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>proxy-injection</artifactId>

--- a/tests/performance/tools/pom.xml
+++ b/tests/performance/tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.performance</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
     <groupId>org.glassfish.jersey.tests.performance.tools</groupId>
     <artifactId>performance-test-tools</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.jersey.tests</groupId>

--- a/tests/stress/pom.xml
+++ b/tests/stress/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests</groupId>
         <artifactId>project</artifactId>
-        <version>2.29.1.payara-p1</version>
+        <version>2.29.1.payara-p2</version>
     </parent>
 
     <artifactId>stress</artifactId>


### PR DESCRIPTION
Truth table for the results:

| BodyReader Found | Empty POST Body | Content-Type Header Specified | Old Result | New Result |
|------------------|-----------------|-------------------------------|------------|------------|
| true             | true            | true                          | error      | null       |
| true             | true            | false                         | null       | null       |
| true             | false           | true                          | read       | read       |
| true             | false           | false                         | read       | read       |
| false            | true            | true                          | error      | null       |
| false            | true            | false                         | null       | null       |
| false            | false           | true                          | error      | error      |
| false            | false           | false                         | error      | error      |

EDIT: This table is now exactly the same before and after; I've limited the fix to JSON null entities. This is because my original commit also caused streams to return as null rather than empty, which broke all streaming.