### PR TITLE
FISH-8662 Update EclipseLink Moxy to 5.0.0-B02, Expressly to 6.0.0-M1, and Grizzly to 4.1.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2334,7 +2334,7 @@
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <jakarta.activation.version>2.0.2</jakarta.activation.version>
         <jakarta.el.version>6.0.0-RC1</jakarta.el.version>
-        <jakarta.el.impl.version>5.0.0-M1</jakarta.el.impl.version>
+        <jakarta.el.impl.version>6.0.0-M1</jakarta.el.impl.version>
         <jakarta.annotation.osgi.version>jakarta.annotation.*;version="[3.0,4)"</jakarta.annotation.osgi.version>
         <jakarta.annotation.version>3.0.0-M1</jakarta.annotation.version>
         <jakarta.decorator.osgi.version>jakarta.decorator.*;version="[4.0,5)"</jakarta.decorator.osgi.version> <!-- CDI -->

--- a/pom.xml
+++ b/pom.xml
@@ -2356,7 +2356,7 @@
         <jsonb.api.version>3.0.0</jsonb.api.version>
         <jsonp.ri.version>1.1.5</jsonp.ri.version>
         <jsonp.jaxrs.version>1.1.5</jsonp.jaxrs.version>
-        <moxy.version>4.0.2</moxy.version>
+        <moxy.version>5.0.0-B02</moxy.version>
         <yasson.version>3.0.3</yasson.version>
         <!-- END of Jakartified -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -2320,7 +2320,7 @@
         <cdi.api.version>4.1.0.RC1</cdi.api.version>
         <cdi.osgi.version>jakarta.enterprise.*;version="[4.0,5)"</cdi.osgi.version>
         <ejb.version>4.0.1</ejb.version>
-        <grizzly2.version>4.0.2</grizzly2.version>
+        <grizzly2.version>4.1.0-M1</grizzly2.version>
         <grizzly.client.version>1.16</grizzly.client.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
         <hk2.version>4.0.0-M1</hk2.version>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -222,6 +222,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.asm</artifactId>
+            <version>9.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-processing</artifactId>
             <scope>test</scope>

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JsonMoxyTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JsonMoxyTest.java
@@ -58,6 +58,7 @@ public class JsonMoxyTest extends AbstractJsonOsgiIntegrationTest {
                 mavenBundle().groupId("org.eclipse.persistence").artifactId("org.eclipse.persistence.core").versionAsInProject(),
                 mavenBundle().groupId("org.eclipse.persistence").artifactId("org.eclipse.persistence.asm").versionAsInProject(),
                 mavenBundle().groupId("org.eclipse.parsson").artifactId("parsson").versionAsInProject(),
+                mavenBundle().groupId("jakarta.json").artifactId("jakarta.json-api").versionAsInProject(),
 
                 // validation
                 mavenBundle().groupId("org.hibernate.validator").artifactId("hibernate-validator").versionAsInProject(),


### PR DESCRIPTION
Updates EclipseLink Moxy to an EE11 compatible version, allowing OSGi to resolve.

The Moxy OSGi test fails due to a ClassNotFoundException, though I'm not currently sure where it comes from. I've made some steps to allow OSGi to resolve, but debugging this test is awkward.